### PR TITLE
Implement Querydsl custom repository with new domain model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/build/
+/.gradle/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # mYcodexTest
-mYcodexTest
+Sample project demonstrating Querydsl projection for JPA relations using Spring Boot 3.
+
+## Build
+Use Gradle to compile and test the project:
+
+```bash
+gradle build
+```

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,32 @@
+plugins {
+    id 'java'
+}
+
+repositories {
+    mavenCentral()
+}
+
+ext {
+    querydslVersion = '5.1.0'
+    springBootVersion = '3.3.0'
+}
+
+dependencies {
+    implementation "org.springframework.boot:spring-boot-starter-data-jpa:${springBootVersion}"
+    implementation "org.springframework.boot:spring-boot-starter:${springBootVersion}"
+    implementation "jakarta.persistence:jakarta.persistence-api:3.1.0"
+    implementation "com.querydsl:querydsl-jpa:${querydslVersion}"
+    annotationProcessor "com.querydsl:querydsl-apt:${querydslVersion}:jakarta"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api:3.1.0"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api:2.1.1"
+    runtimeOnly 'com.h2database:h2:2.2.224'
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+sourceSets {
+    main.java.srcDirs += "build/generated/sources/annotationProcessor/java/main"
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'demo'

--- a/src/main/java/com/example/demo/dto/OrderProjection.java
+++ b/src/main/java/com/example/demo/dto/OrderProjection.java
@@ -1,0 +1,37 @@
+package com.example.demo.dto;
+
+public class OrderProjection {
+    private Long orderId;
+    private Long customerId;
+    private String customerName;
+    private Long recipientId;
+    private String recipientAddress;
+
+    public OrderProjection(Long orderId, Long customerId, String customerName, Long recipientId, String recipientAddress) {
+        this.orderId = orderId;
+        this.customerId = customerId;
+        this.customerName = customerName;
+        this.recipientId = recipientId;
+        this.recipientAddress = recipientAddress;
+    }
+
+    public Long getOrderId() {
+        return orderId;
+    }
+
+    public Long getCustomerId() {
+        return customerId;
+    }
+
+    public String getCustomerName() {
+        return customerName;
+    }
+
+    public Long getRecipientId() {
+        return recipientId;
+    }
+
+    public String getRecipientAddress() {
+        return recipientAddress;
+    }
+}

--- a/src/main/java/com/example/demo/entity/Customer.java
+++ b/src/main/java/com/example/demo/entity/Customer.java
@@ -1,0 +1,36 @@
+package com.example.demo.entity;
+
+import jakarta.persistence.*;
+
+@Entity
+public class Customer {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    @OneToOne
+    @JoinColumn(name = "order_id")
+    private Order order;
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Order getOrder() {
+        return order;
+    }
+
+    public void setOrder(Order order) {
+        this.order = order;
+    }
+}

--- a/src/main/java/com/example/demo/entity/Item.java
+++ b/src/main/java/com/example/demo/entity/Item.java
@@ -1,0 +1,24 @@
+package com.example.demo.entity;
+
+import jakarta.persistence.*;
+
+@Entity
+public class Item {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/com/example/demo/entity/Order.java
+++ b/src/main/java/com/example/demo/entity/Order.java
@@ -1,0 +1,50 @@
+package com.example.demo.entity;
+
+import jakarta.persistence.*;
+import java.util.List;
+
+@Entity
+public class Order {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(mappedBy = "order", cascade = CascadeType.ALL)
+    private Customer customer;
+
+    @OneToMany
+    @JoinColumn(name = "order_id")
+    private List<OrderItem> orderItems;
+
+    @OneToOne
+    @JoinColumn(name = "recipient_id")
+    private Recipient recipient;
+
+    public Long getId() {
+        return id;
+    }
+
+    public Customer getCustomer() {
+        return customer;
+    }
+
+    public void setCustomer(Customer customer) {
+        this.customer = customer;
+    }
+
+    public List<OrderItem> getOrderItems() {
+        return orderItems;
+    }
+
+    public void setOrderItems(List<OrderItem> orderItems) {
+        this.orderItems = orderItems;
+    }
+
+    public Recipient getRecipient() {
+        return recipient;
+    }
+
+    public void setRecipient(Recipient recipient) {
+        this.recipient = recipient;
+    }
+}

--- a/src/main/java/com/example/demo/entity/OrderItem.java
+++ b/src/main/java/com/example/demo/entity/OrderItem.java
@@ -1,0 +1,36 @@
+package com.example.demo.entity;
+
+import jakarta.persistence.*;
+
+@Entity
+public class OrderItem {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private int quantity;
+
+    @ManyToOne
+    @JoinColumn(name = "item_id")
+    private Item item;
+
+    public Long getId() {
+        return id;
+    }
+
+    public int getQuantity() {
+        return quantity;
+    }
+
+    public void setQuantity(int quantity) {
+        this.quantity = quantity;
+    }
+
+    public Item getItem() {
+        return item;
+    }
+
+    public void setItem(Item item) {
+        this.item = item;
+    }
+}

--- a/src/main/java/com/example/demo/entity/Recipient.java
+++ b/src/main/java/com/example/demo/entity/Recipient.java
@@ -1,0 +1,24 @@
+package com.example.demo.entity;
+
+import jakarta.persistence.*;
+
+@Entity
+public class Recipient {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String address;
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+}

--- a/src/main/java/com/example/demo/repository/CustomerRepository.java
+++ b/src/main/java/com/example/demo/repository/CustomerRepository.java
@@ -1,0 +1,7 @@
+package com.example.demo.repository;
+
+import com.example.demo.entity.Customer;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CustomerRepository extends JpaRepository<Customer, Long> {
+}

--- a/src/main/java/com/example/demo/repository/OrderItemRepository.java
+++ b/src/main/java/com/example/demo/repository/OrderItemRepository.java
@@ -1,0 +1,7 @@
+package com.example.demo.repository;
+
+import com.example.demo.entity.OrderItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
+}

--- a/src/main/java/com/example/demo/repository/OrderRepository.java
+++ b/src/main/java/com/example/demo/repository/OrderRepository.java
@@ -1,0 +1,15 @@
+package com.example.demo.repository;
+
+import com.example.demo.entity.Order;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.demo.repository.OrderRepositoryCustom;
+
+/**
+ * Main repository interface for {@link Order}.
+ * <p>
+ * Extends {@link OrderRepositoryCustom} to expose custom Querydsl queries.
+ */
+
+public interface OrderRepository extends JpaRepository<Order, Long>, OrderRepositoryCustom {
+}

--- a/src/main/java/com/example/demo/repository/OrderRepositoryCustom.java
+++ b/src/main/java/com/example/demo/repository/OrderRepositoryCustom.java
@@ -1,0 +1,8 @@
+package com.example.demo.repository;
+
+import com.example.demo.dto.OrderProjection;
+import java.util.List;
+
+public interface OrderRepositoryCustom {
+    List<OrderProjection> findOrderWithRelations();
+}

--- a/src/main/java/com/example/demo/repository/OrderRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/OrderRepositoryImpl.java
@@ -1,0 +1,41 @@
+package com.example.demo.repository;
+
+import com.example.demo.dto.OrderProjection;
+import com.example.demo.entity.Order;
+import com.example.demo.entity.QCustomer;
+import com.example.demo.entity.QOrder;
+import com.example.demo.entity.QOrderItem;
+import com.example.demo.entity.QRecipient;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+
+public class OrderRepositoryImpl implements OrderRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    public OrderRepositoryImpl(JPAQueryFactory queryFactory) {
+        this.queryFactory = queryFactory;
+    }
+
+    @Override
+    public List<OrderProjection> findOrderWithRelations() {
+        QOrder order = QOrder.order;
+        QCustomer customer = QCustomer.customer;
+        QOrderItem orderItem = QOrderItem.orderItem;
+        QRecipient recipient = QRecipient.recipient;
+
+        return queryFactory
+                .select(Projections.constructor(OrderProjection.class,
+                        order.id,
+                        customer.id,
+                        customer.name,
+                        recipient.id,
+                        recipient.address))
+                .from(order)
+                .join(order.customer, customer)
+                .leftJoin(order.orderItems, orderItem)
+                .leftJoin(order.recipient, recipient)
+                .fetch();
+    }
+}

--- a/src/main/java/com/example/demo/repository/RecipientRepository.java
+++ b/src/main/java/com/example/demo/repository/RecipientRepository.java
@@ -1,0 +1,7 @@
+package com.example.demo.repository;
+
+import com.example.demo.entity.Recipient;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RecipientRepository extends JpaRepository<Recipient, Long> {
+}


### PR DESCRIPTION
## Summary
- upgrade build to Spring Boot 3 and Java 17
- rename entities to `Order`, `Customer`, `OrderItem`, `Recipient` and add `Item`
- update repositories and DTO to match new entity names
- implement custom Querydsl repository for `Order`
- document extension of the custom repository in `OrderRepository`

## Testing
- `gradle test --no-daemon --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68486149a33883219ce3bcbe449d142c